### PR TITLE
Also publish wheels to pypi

### DIFF
--- a/.github/workflows/manual_publish.yml
+++ b/.github/workflows/manual_publish.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: '3.7'
         architecture: 'x64'
     - name: Install dependencies
-      run: python -m pip install jupyterlab jupyter_packaging
+      run: python -m pip install jupyterlab jupyter_packaging wheel
     - name: Build
       run: |
         npm config set ignore-scripts true
@@ -31,7 +31,7 @@ jobs:
         jupyter labextension list 2>&1 | grep -ie "@lckr/jupyterlab_variableinspector.*OK"
         python -m jupyterlab.browser_check
     - name: Package
-      run: python setup.py sdist
+      run: python setup.py sdist bdist_wheel
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:


### PR DESCRIPTION
This will make installation a little bit quicker when people install from pip as they won't have to build the wheel (PEP 517) themselves.
Below is from an install from pypi:


![image](https://user-images.githubusercontent.com/10111092/114914862-d8350f80-9df0-11eb-97d5-860b78360b29.png)

![image](https://user-images.githubusercontent.com/10111092/114914812-c7849980-9df0-11eb-9ae4-58ec4cab6ccb.png)
