### PR TITLE
Lazy inspection

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -29,9 +29,19 @@ abstract class AbstractHandler implements IVariableInspector.IInspectable {
   >(this);
   protected _connector: KernelConnector;
   protected _rendermime: IRenderMimeRegistry | null = null;
+  private _enabled: boolean;
 
   constructor(connector: KernelConnector) {
     this._connector = connector;
+    this._enabled = false;
+  }
+
+  get enabled(): boolean {
+    return this._enabled;
+  }
+
+  set enabled(value: boolean) {
+    this._enabled = value;
   }
 
   get disposed(): ISignal<this, void> {
@@ -138,10 +148,15 @@ export class VariableInspectionHandler extends AbstractHandler {
   get ready(): Promise<void> {
     return this._ready;
   }
+
   /**
    * Performs an inspection by sending an execute request with the query command to the kernel.
    */
   performInspection(): void {
+    if (!this.enabled) {
+      return;
+    }
+
     const content: KernelMessage.IExecuteRequestMsg['content'] = {
       code: this._queryCommand,
       stop_on_error: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import { ICommandPalette, WidgetTracker } from '@jupyterlab/apputils';
 
 import {
   ILabShell,
-  ILayoutRestorer,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
@@ -35,13 +34,12 @@ namespace CommandIDs {
  */
 const variableinspector: JupyterFrontEndPlugin<IVariableInspectorManager> = {
   id: '@lckr/jupyterlab_variableinspector',
-  requires: [ICommandPalette, ILayoutRestorer, ILabShell],
+  requires: [ICommandPalette, ILabShell],
   provides: IVariableInspectorManager,
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     palette: ICommandPalette,
-    restorer: ILayoutRestorer,
     labShell: ILabShell
   ): IVariableInspectorManager => {
     const manager = new VariableInspectorManager();
@@ -72,13 +70,6 @@ const variableinspector: JupyterFrontEndPlugin<IVariableInspectorManager> = {
 
       return panel;
     }
-
-    // Enable state restoration
-    restorer.restore(tracker, {
-      command,
-      args: () => ({}),
-      name: () => 'variableinspector'
-    });
 
     // Add command to palette
     app.commands.addCommand(command, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { ICommandPalette, WidgetTracker } from '@jupyterlab/apputils';
 
 import {
   ILabShell,
+  ILayoutRestorer,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
@@ -34,12 +35,13 @@ namespace CommandIDs {
  */
 const variableinspector: JupyterFrontEndPlugin<IVariableInspectorManager> = {
   id: '@lckr/jupyterlab_variableinspector',
-  requires: [ICommandPalette, ILabShell],
+  requires: [ICommandPalette, ILayoutRestorer, ILabShell],
   provides: IVariableInspectorManager,
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     palette: ICommandPalette,
+    restorer: ILayoutRestorer,
     labShell: ILabShell
   ): IVariableInspectorManager => {
     const manager = new VariableInspectorManager();
@@ -70,6 +72,13 @@ const variableinspector: JupyterFrontEndPlugin<IVariableInspectorManager> = {
 
       return panel;
     }
+
+    // Enable state restoration
+    restorer.restore(tracker, {
+      command,
+      args: () => ({}),
+      name: () => 'variableinspector'
+    });
 
     // Add command to palette
     app.commands.addCommand(command, {

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -176,10 +176,10 @@ def _jupyterlab_variableinspector_dict_list():
     vardic = [
         {
             'varName': _v,
-            'varType': type(eval(_v)).__name__, 
-            'varSize': str(_jupyterlab_variableinspector_getsizeof(eval(_v))), 
-            'varShape': str(_jupyterlab_variableinspector_getshapeof(eval(_v))) if _jupyterlab_variableinspector_getshapeof(eval(_v)) else '', 
-            'varContent': str(_jupyterlab_variableinspector_getcontentof(eval(_v))), 
+            'varType': type(eval(_v)).__name__,
+            'varSize': str(_jupyterlab_variableinspector_getsizeof(eval(_v))),
+            'varShape': str(_jupyterlab_variableinspector_getshapeof(eval(_v))) if _jupyterlab_variableinspector_getshapeof(eval(_v)) else '',
+            'varContent': str(_jupyterlab_variableinspector_getcontentof(eval(_v))),
             'isMatrix': _jupyterlab_variableinspector_is_matrix(eval(_v)),
             'isWidget': _jupyterlab_variableinspector_is_widget(type(eval(_v)))
         }
@@ -226,7 +226,7 @@ def _jupyterlab_variableinspector_displaywidget(widget):
 
 
 def _jupyterlab_variableinspector_default(o):
-    if isinstance(o, __np.number): return int(o)  
+    if isinstance(o, __np.number): return int(o)
     raise TypeError
 
 
@@ -236,10 +236,10 @@ def _jupyterlab_variableinspector_deletevariable(x):
 
   static r_script = `library(repr)
 
-.ls.objects = function (pos = 1, pattern, order.by, decreasing = FALSE, head = FALSE, 
-    n = 5) 
+.ls.objects = function (pos = 1, pattern, order.by, decreasing = FALSE, head = FALSE,
+    n = 5)
 {
-    napply <- function(names, fn) sapply(names, function(x) fn(get(x, 
+    napply <- function(names, fn) sapply(names, function(x) fn(get(x,
         pos = pos)))
     names <- ls(pos = pos, pattern = pattern)
     if (length(names) == 0) {
@@ -251,11 +251,11 @@ def _jupyterlab_variableinspector_deletevariable(x):
     obj.size <- napply(names, object.size)
     obj.dim <- t(napply(names, function(x) as.numeric(dim(x))[1:2]))
     obj.content <- rep("NA", length(names))
-    has_no_dim <- is.na(obj.dim)[1:length(names)]                        
+    has_no_dim <- is.na(obj.dim)[1:length(names)]
     obj.dim[has_no_dim, 1] <- napply(names, length)[has_no_dim]
     vec <- (obj.type != "function")
     obj.content[vec] <- napply(names[vec], function(x) toString(x, width = 154)[1])
-                      
+
     obj.rownames <- napply(names, rownames)
     has_rownames <- obj.rownames != "NULL"
     obj.rownames <- sapply(obj.rownames[has_rownames], function(x) paste(x,
@@ -264,24 +264,24 @@ def _jupyterlab_variableinspector_deletevariable(x):
     obj.rownames <- ifelse(nchar(obj.rownames) > 154, obj.rownames.short, obj.rownames)
     obj.rownames <- sapply(obj.rownames, function(x) paste("Row names: ",x))
     obj.content[has_rownames] <- obj.rownames
-                               
-                               
+
+
     obj.colnames <- napply(names, colnames)
     has_colnames <- obj.colnames != "NULL"
-    obj.colnames <- sapply(obj.colnames[has_colnames], function(x) paste(x, 
+    obj.colnames <- sapply(obj.colnames[has_colnames], function(x) paste(x,
         collapse = ", "))
-    obj.colnames.short <- sapply(obj.colnames, function(x) paste(substr(x, 
+    obj.colnames.short <- sapply(obj.colnames, function(x) paste(substr(x,
         1, 150), "...."))
-    obj.colnames <- ifelse(nchar(obj.colnames) > 154, obj.colnames.short, 
+    obj.colnames <- ifelse(nchar(obj.colnames) > 154, obj.colnames.short,
         obj.colnames)
     obj.colnames <- sapply(obj.colnames, function(x) paste("Column names: ",x))
-                    
+
     obj.content[has_colnames] <- obj.colnames
-                           
+
     is_function <- (obj.type == "function")
     obj.content[is_function] <- napply(names[is_function], function(x) paste(strsplit(repr_text(x),")")[[1]][1],")",sep=""))
     obj.content <- unlist(obj.content, use.names = FALSE)
-    
+
 
     out <- data.frame(obj.type, obj.size, obj.dim)
     names(out) <- c("varType", "varSize", "Rows", "Columns")
@@ -292,10 +292,10 @@ def _jupyterlab_variableinspector_deletevariable(x):
     out <- out[, !(names(out) %in% c("Rows", "Columns"))]
     rownames(out) <- NULL
     print(out)
-    if (!missing(order.by)) 
-        out <- out[order(out[[order.by]], decreasing = decreasing), 
+    if (!missing(order.by))
+        out <- out[order(out[[order.by]], decreasing = decreasing),
             ]
-    if (head) 
+    if (head)
         out <- head(out, n)
     jsonlite::toJSON(out)
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -38,6 +38,7 @@ export namespace IVariableInspector {
   export interface IInspectable extends IObservableDisposable {
     inspected: ISignal<IInspectable, IVariableInspectorUpdate>;
     rendermime: IRenderMimeRegistry | null;
+    enabled: boolean;
     performInspection(): void;
     performMatrixInspection(
       varName: string,

--- a/src/variableinspector.ts
+++ b/src/variableinspector.ts
@@ -36,6 +36,7 @@ provideJupyterDesignSystem().register(
 );
 
 import wildcardMatch from 'wildcard-match';
+import { Message } from '@lumino/messaging';
 
 const TITLE_CLASS = 'jp-VarInspector-title';
 const PANEL_CLASS = 'jp-VarInspector';
@@ -233,12 +234,14 @@ export class VariableInspectorPanel
     }
     //Remove old subscriptions
     if (this._source) {
+      this._source.enabled = false;
       this._source.inspected.disconnect(this.onInspectorUpdate, this);
       this._source.disposed.disconnect(this.onSourceDisposed, this);
     }
     this._source = source;
     //Subscribe to new object
     if (this._source) {
+      this._source.enabled = true;
       this._source.inspected.connect(this.onInspectorUpdate, this);
       this._source.disposed.connect(this.onSourceDisposed, this);
       this._source.performInspection();
@@ -252,8 +255,18 @@ export class VariableInspectorPanel
     if (this.isDisposed) {
       return;
     }
+    if (this.source) {
+      this.source.enabled = false;
+    }
     this.source = null;
     super.dispose();
+  }
+
+  protected onCloseRequest(msg: Message): void {
+    super.onCloseRequest(msg);
+    if (this._source) {
+      this._source.enabled = false;
+    }
   }
 
   protected onInspectorUpdate(

--- a/src/variableinspector.ts
+++ b/src/variableinspector.ts
@@ -269,6 +269,14 @@ export class VariableInspectorPanel
     }
   }
 
+  protected onAfterShow(msg: Message): void {
+    super.onAfterShow(msg);
+    if (this._source) {
+      this._source.enabled = true;
+      this._source.performInspection();
+    }
+  }
+
   protected onInspectorUpdate(
     sender: any,
     allArgs: IVariableInspector.IVariableInspectorUpdate


### PR DESCRIPTION
Do not request anything from the kernel if the variable inspector is not currently open

This fixes performances issues, at least when the UI for the variable inspector is not open https://github.com/jupyterlab-contrib/jupyterlab-variableInspector/issues/307

cc. @achhina @trungleduc