### PR TITLE
Small speedup improvement on the inspection logic in Python

### DIFF
--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -152,7 +152,7 @@ def _jupyterlab_variableinspector_dict_list():
     def keep_cond(v):
         try:
             obj = eval(v)
-            if isinstance(obj, str):
+            if isinstance(obj, (bool, str, list, int, float, type(None))):
                 return True
             if __tf and isinstance(obj, __tf.Variable):
                 return True


### PR DESCRIPTION
In addition to https://github.com/jupyterlab-contrib/jupyterlab-variableInspector/pull/309 to get through improving the extension performance #307 

--- 

This PR adds more checks for simple primitive types before doing the "heavy load" for more complex types.

In this situation:

![Screenshot from 2024-08-30 11-34-40](https://github.com/user-attachments/assets/dd92d5b6-f0c9-40cf-bc08-48c48f731279)

It goes from:
`803 ms ± 19.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)` for `_jupyterlab_variableinspector_dict_list`
to
`265 ms ± 14 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)`

**Note that this means without #309 and this PR we were adding almost 1 second delay for each cell execution when the variable inspector UI was not open.** Even though I'm not testing with so many variables and my arrays aren't too big.

This is a first PR of hopefully more performance improvements