### PR TITLE
Some more performance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
         "yjs": "^13.5.40"
     },
     "jupyterlab": {
+        "schemaDir": "schema",
         "extension": true,
         "outputDir": "lckr_jupyterlab_variableinspector/labextension",
         "sharedPackages": {

--- a/schema/jupyterlab-variableInspector-settings.json
+++ b/schema/jupyterlab-variableInspector-settings.json
@@ -1,10 +1,12 @@
 {
-  "title": "jupyterlab-variableInspector settings",
+  "jupyter.lab.setting-icon": "ui-components:list",
+  "title": "Variable Inspector",
   "description": "Settings for the jupyterlab-variableInspector extension.",
   "type": "object",
   "properties": {
     "maxItems": {
       "type": "number",
+      "minimum": 0,
       "title": "Maximum number of items",
       "description": "The maximum number of items to show in lists/dicts etc",
       "default": 10

--- a/schema/jupyterlab-variableInspector-settings.json
+++ b/schema/jupyterlab-variableInspector-settings.json
@@ -1,0 +1,13 @@
+{
+  "title": "jupyterlab-variableInspector settings",
+  "description": "Settings for the jupyterlab-variableInspector extension.",
+  "type": "object",
+  "properties": {
+    "maxItems": {
+      "type": "number",
+      "title": "Maximum number of items",
+      "description": "The maximum number of items to show in lists/dicts etc",
+      "default": 10
+    }
+  }
+}

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -16,6 +16,8 @@ export abstract class Languages {
   static py_script = `import json
 import sys
 from importlib import __import__
+from itertools import islice
+import collections
 from IPython import get_ipython
 from IPython.core.magics.namespace import NamespaceMagics
 
@@ -108,6 +110,17 @@ def _jupyterlab_variableinspector_getcontentof(x):
             content = str(x)
         else:
             content = f"[{x[0]}, {x[1]}, {x[2]}, ..., {x[-1]}]"
+    elif isinstance(x, collections.abc.Mapping):
+        if len(x.keys()) < 10:
+            content = str(x)
+        else:
+            first_ten_keys = list(islice(x.keys(), 10))
+            content = "{"
+            for idx, key in enumerate(first_ten_keys):
+                if idx > 0:
+                    content += ", "
+                content += f'"{key}": {x[key]}'
+            content += ", ...}"
     elif __pd and isinstance(x, __pd.DataFrame):
         colnames = ', '.join(x.columns.map(str))
         content = "Columns: %s" % colnames
@@ -159,7 +172,7 @@ def _jupyterlab_variableinspector_dict_list():
     def keep_cond(v):
         try:
             obj = eval(v)
-            if isinstance(obj, (bool, str, list, tuple, int, float, type(None))):
+            if isinstance(obj, (bool, str, list, tuple, collections.abc.Mapping, int, float, type(None))):
                 return True
             if __tf and isinstance(obj, __tf.Variable):
                 return True

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -101,7 +101,14 @@ def _jupyterlab_variableinspector_getshapeof(x):
 def _jupyterlab_variableinspector_getcontentof(x):
     # returns content in a friendly way for python variables
     # pandas and numpy
-    if __pd and isinstance(x, __pd.DataFrame):
+    if isinstance(x, (bool, str, int, float, type(None))):
+        content = str(x)
+    elif isinstance(x, (list, tuple)):
+        if len(x) < 10:
+            content = str(x)
+        else:
+            content = f"[{x[0]}, {x[1]}, {x[2]}, ..., {x[-1]}]"
+    elif __pd and isinstance(x, __pd.DataFrame):
         colnames = ', '.join(x.columns.map(str))
         content = "Columns: %s" % colnames
     elif __pd and isinstance(x, __pd.Series):
@@ -152,7 +159,7 @@ def _jupyterlab_variableinspector_dict_list():
     def keep_cond(v):
         try:
             obj = eval(v)
-            if isinstance(obj, (bool, str, list, int, float, type(None))):
+            if isinstance(obj, (bool, str, list, tuple, int, float, type(None))):
                 return True
             if __tf and isinstance(obj, __tf.Variable):
                 return True

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -53,6 +53,10 @@ export namespace IVariableInspector {
     performDelete(varName: string): void;
   }
 
+  export interface ISettings {
+    maxItems: number;
+  }
+
   export interface IVariableInspectorUpdate {
     title: IVariableTitle;
     payload: Array<IVariable>;
@@ -67,6 +71,7 @@ export namespace IVariableInspector {
     isMatrix: boolean;
     isWidget: boolean;
   }
+
   export interface IVariableTitle {
     kernelName?: string;
     contextName?: string; //Context currently reserved for special information.


### PR DESCRIPTION
Still playing with my case from https://github.com/jupyterlab-contrib/jupyterlab-variableInspector/pull/311 for improving https://github.com/jupyterlab-contrib/jupyterlab-variableInspector/issues/307

I can go down to `487 μs ± 10.2 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)` by improving the processing of big lists and tuples.