### PR TITLE
Improve pandas dataframe inspection

### DIFF
--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -77,9 +77,12 @@ def _jupyterlab_variableinspector_getsizeof(x):
     elif __torch and isinstance(x, __torch.Tensor):
         return x.element_size() * x.nelement()
     elif __pd and type(x).__name__ == 'DataFrame':
-        # DO NOT CALL df.memory_usage() as this can be very costly
-        # to the point of crashing the kernel
-        return "?"
+        # DO NOT CALL df.memory_usage() for big dataframes as this can be very costly
+        # to the point of making the kernel unresponsive or crashing it
+        if len(x.columns) < 10_000:
+            return x.memory_usage().sum()
+        else:
+            return "?"
     else:
         return sys.getsizeof(x)
 

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -77,7 +77,9 @@ def _jupyterlab_variableinspector_getsizeof(x):
     elif __torch and isinstance(x, __torch.Tensor):
         return x.element_size() * x.nelement()
     elif __pd and type(x).__name__ == 'DataFrame':
-        return x.memory_usage().sum()
+        # DO NOT CALL df.memory_usage() as this can be very costly
+        # to the point of crashing the kernel
+        return "?"
     else:
         return sys.getsizeof(x)
 
@@ -136,8 +138,17 @@ def _jupyterlab_variableinspector_getcontentof(x):
                 content += f'"{key}": {x[key]}'
             content += ", ...}"
     elif __pd and isinstance(x, __pd.DataFrame):
-        colnames = ', '.join(x.columns.map(str))
-        content = "Columns: %s" % colnames
+        if len(x.columns) <= _jupyterlab_variableinspector_maxitems:
+            colnames = ', '.join(x.columns.map(str))
+            content = "Columns: %s" % colnames
+        else:
+            content = "Columns: "
+            for idx in range(_jupyterlab_variableinspector_maxitems):
+                if idx > 0:
+                    content += ", "
+                content += str(x.columns[idx])
+            content += ", ..."
+            return content
     elif __pd and isinstance(x, __pd.Series):
         content = str(x.values).replace(" ", ", ")[1:-1]
         content = content.replace("\\n", "")


### PR DESCRIPTION
Improve inspection of dataframes with many columns.

Prior to this PR, inspecting after running the following code would eventually make my laptop **go out of memory and crash!!!**. 
With this PR, the inspection code takes: `414 μs ± 6.29 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)` and the kernel stays alive.

One pain point was [`df.memory_usage`](https://github.com/pandas-dev/pandas/blob/main/pandas/core/frame.py#L3544) which creates a whole new dataframe. We need to find a smarter/faster way to compute the memory usage and disable this feature for now (what I do in the PR).

```python
import pandas as pd
import numpy as np

# Set the seed for reproducibility
np.random.seed(42)

# Calculate the number of rows to approximate 1 GB of memory
num_rows = 10
num_cols = 50_000_000

# Create a DataFrame with the calculated size
large_df = pd.DataFrame(
    np.random.rand(num_rows, num_cols),
    columns=[f'col_{i+1}' for i in range(num_cols)]
)
```