### PR TITLE
Variable inspector widget buttons visibility and delete functionality

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -226,8 +226,8 @@ export class VariableInspectionHandler extends AbstractHandler {
             break;
           }
           case 'error':
-            console.log(response);
-            reject("Kernel error on 'matrixQuery' call!");
+            const error = response as KernelMessage.IErrorMsg;
+            reject(error);
             break;
           default:
             break;

--- a/src/inspectorscripts.ts
+++ b/src/inspectorscripts.ts
@@ -62,6 +62,9 @@ def _check_imported():
     __ipywidgets = _attempt_import('ipywidgets')
     __xr = _attempt_import('xarray')
 
+def _verify_import(module,name):
+    if module is None:
+        raise ImportError(f"{name} is required to inspect the variable. Please import it and try again.")
 
 def _jupyterlab_variableinspector_changesettings(maxitems, **kwargs):
     global _jupyterlab_variableinspector_maxitems
@@ -254,7 +257,8 @@ def _jupyterlab_variableinspector_getmatrixcontent(x, max_rows=10000):
         if threshold is not None:
             x = x.head(threshold)
         return x.to_json(orient="table", default_handler=_jupyterlab_variableinspector_default, force_ascii=False)
-    elif __np and __pd and type(x).__name__ == "ndarray":
+    elif __np and type(x).__name__ == "ndarray":
+        _verify_import(__pd, "pandas")
         df = __pd.DataFrame(x)
         return _jupyterlab_variableinspector_getmatrixcontent(df)
     elif __tf and (isinstance(x, __tf.Variable) or isinstance(x, __tf.Tensor)):
@@ -267,6 +271,7 @@ def _jupyterlab_variableinspector_getmatrixcontent(x, max_rows=10000):
         df = x.to_numpy()
         return _jupyterlab_variableinspector_getmatrixcontent(df)
     elif isinstance(x, list):
+        _verify_import(__pd, "pandas")
         s = __pd.Series(x)
         return _jupyterlab_variableinspector_getmatrixcontent(s)
 

--- a/style/base.css
+++ b/style/base.css
@@ -80,13 +80,13 @@
 
 .jp-VarInspector-deleteButton {
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   width: 1em;
 }
 
 .jp-VarInspector-inspectButton {
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   width: 1em;
 }
 


### PR DESCRIPTION
**Summary:**

- Made the delete and inspect content buttons visible by adjusting CSS (`display: center`) and replaced inappropriate icons:
  - Search icon replaced with an inspector icon.
  - Remove icon replaced with a delete icon for better clarity.

- Enhanced the delete functionality:
  - Previously, the delete button only removed variables from the table but not from the kernel, causing them to reappear on re-inspection.
  - Now, variables are fully removed from both the table and the kernel upon deletion.

- Addressed an inspection failure for lists and NumPy arrays:
  - When not using pandas, inspecting lists and NumPy arrays would fail due to pandas dependencies.
  - Added an alert message to notify users to import necessary modules if inspection fails, guiding them to resolve the issue.

####  Changes except `kernel deletion functionality`  can be viewed in this SnapShot

#### Before: Unclear Buttons and unaddressed error 

![image](https://github.com/user-attachments/assets/fede2f60-99d0-46db-b732-84fe803de6e8)

#### After: Clear Buttons and resolved error

![Screenshot from 2024-10-19 17-24-39](https://github.com/user-attachments/assets/eb54290b-a92c-430d-819a-90de6de2c415)


Please let me know if further enhancement is required on this.